### PR TITLE
Add ability to control generation of `createdAt` and `updatedAt` field through FirestoreClass properties

### DIFF
--- a/compiler/src/main/kotlin/com/otaliastudios/firestore/compiler/Processor.kt
+++ b/compiler/src/main/kotlin/com/otaliastudios/firestore/compiler/Processor.kt
@@ -72,10 +72,9 @@ class Processor : AbstractProcessor() {
             // The properties we want to support are those delegated with by this(),
             // the rest is probably class state that should not be in firestore.
             it.delegated
-            true
         }.filter {
             logInfo("INSPECTING! Property:${it.name} Initializer:${it.initializer} Getter:${it.getter} ReceiverType:${it.receiverType}")
-            false
+            true
         }.forEach { property ->
             logInfo("Inspecting property ${property.name} of type ${property.type}.")
             val annotationsSpecs = property.annotations + (property.getter?.annotations ?: listOf())

--- a/compiler/src/main/kotlin/com/otaliastudios/firestore/compiler/shared.kt
+++ b/compiler/src/main/kotlin/com/otaliastudios/firestore/compiler/shared.kt
@@ -7,7 +7,7 @@ package com.otaliastudios.firestore
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class FirestoreClass
+annotation class FirestoreClass(val addCreatedAt: Boolean = true, val addUpdatedAt: Boolean = true)
 
 @Suppress("unused")
 interface FirestoreMetadata {

--- a/demo/src/main/kotlin/com/otalistudios/firestore/demo/User.kt
+++ b/demo/src/main/kotlin/com/otalistudios/firestore/demo/User.kt
@@ -2,16 +2,20 @@
 
 package com.otalistudios.firestore.demo
 
+import com.google.firebase.firestore.Exclude
 import com.otaliastudios.firestore.FirestoreClass
 import com.otaliastudios.firestore.FirestoreDocument
 import com.otaliastudios.firestore.FirestoreList
 import com.otaliastudios.firestore.FirestoreMap
 
-@FirestoreClass
+@FirestoreClass(addUpdatedAt = false)
 class User : FirestoreDocument() {
     var type: Int by this
     var imageUrl: String? by this("image_url")
     var messages: Messages by this
+    var ignoredByLackOfPropertyDelegate: Boolean = true
+    // FIXME: This is currently not working. KotlinPoet issue?
+    @get:Exclude var ignoredByAnnotation: Boolean by this
 
     @FirestoreClass
     class Messages : FirestoreList<Message>()

--- a/firestore/build.gradle.kts
+++ b/firestore/build.gradle.kts
@@ -46,6 +46,7 @@ android {
 
 dependencies {
     api("com.google.firebase:firebase-firestore-ktx:21.6.0")
+    implementation(kotlin("reflect", "1.4.0"))
 }
 
 publisher {

--- a/firestore/src/main/kotlin/com/otaliastudios/firestore/FirestoreClass.kt
+++ b/firestore/src/main/kotlin/com/otaliastudios/firestore/FirestoreClass.kt
@@ -13,5 +13,5 @@ import androidx.annotation.Keep
 @Keep
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-public annotation class FirestoreClass
+public annotation class FirestoreClass(val addCreatedAt: Boolean = true, val addUpdatedAt: Boolean = true)
 // Keep in sync with compiler!

--- a/firestore/src/main/kotlin/com/otaliastudios/firestore/FirestoreDocument.kt
+++ b/firestore/src/main/kotlin/com/otaliastudios/firestore/FirestoreDocument.kt
@@ -58,10 +58,10 @@ public abstract class FirestoreDocument(
     }
 
     @get:Keep @set:Keep
-    public var createdAt: Timestamp? by this
+    public var createdAt: Timestamp? by this()
 
     @get:Keep @set:Keep
-    public var updatedAt: Timestamp? by this
+    public var updatedAt: Timestamp? by this()
 
     internal var cacheState: FirestoreCacheState = FirestoreCacheState.FRESH
 

--- a/firestore/src/main/kotlin/com/otaliastudios/firestore/FirestoreFieldDelegate.kt
+++ b/firestore/src/main/kotlin/com/otaliastudios/firestore/FirestoreFieldDelegate.kt
@@ -19,7 +19,7 @@ internal class FirestoreFieldDelegate<MapType, ValueType : MapType>(private val 
         @Suppress("UNCHECKED_CAST")
         var what = thisRef[property.field] as ValueType
         if (what == null) {
-            val metadata = this::class.metadata
+            val metadata = thisRef::class.metadata
             if (metadata != null && !metadata.isNullable(property.field)) {
                 what = metadata.create<ValueType>(property.field)!!
                 thisRef[property.field] = what

--- a/firestore/src/main/kotlin/com/otaliastudios/firestore/FirestoreMap.kt
+++ b/firestore/src/main/kotlin/com/otaliastudios/firestore/FirestoreMap.kt
@@ -105,7 +105,8 @@ public open class FirestoreMap<T>(source: Map<String, T>? = null) : BaseObservab
     protected open fun <K> onCreateFirestoreMap(key: String): FirestoreMap<K> {
         val metadata = this::class.metadata
         var candidate = metadata?.create<FirestoreMap<K>>(key)
-        candidate = candidate ?: metadata?.createInnerType()
+        // FIXME: This line is causing crashed when a map is removed from a FirestoreDocument subtype
+        //candidate = candidate ?: metadata?.createInnerType()
         candidate = candidate ?: FirestoreMap()
         return candidate
     }
@@ -113,7 +114,8 @@ public open class FirestoreMap<T>(source: Map<String, T>? = null) : BaseObservab
     protected open fun <K: Any> onCreateFirestoreList(key: String): FirestoreList<K> {
         val metadata = this::class.metadata
         var candidate = metadata?.create<FirestoreList<K>>(key)
-        candidate = candidate ?: metadata?.createInnerType()
+        // FIXME: This line is causing crashed when a map is removed from a FirestoreDocument subtype
+        //candidate = candidate ?: metadata?.createInnerType()
         candidate = candidate ?: FirestoreList()
         return candidate
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@ org.gradle.jvmargs=-Xmx3072m
 
 android.enableJetifier=true
 android.useAndroidX=true
+kapt.use.worker.api=true
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Hi,

this pull request features a couple of fixes and adds the ability to control the generation of `createdAt` and `updatedAt` field through FirestoreClass properties.

I'd appreciate a quick turnaround if possible as my worked is blocked without this.

thanks again for your great work!

Daniel